### PR TITLE
QSPI: Add a bypass mode for direct SPI IO and support for wider modes

### DIFF
--- a/riscv-demo/riscv_demo/ips/qspi/qspi_flash.py
+++ b/riscv-demo/riscv_demo/ips/qspi/qspi_flash.py
@@ -54,9 +54,9 @@ class _RawTxDataField(csr.FieldAction):
 class WishboneQSPIFlashController(wiring.Component):
 
     class Config(csr.Register, access="rw"):
-        raw_enable:  csr.Field(csr.action.RW, 1)
-        width:       csr.Field(csr.action.RW, QSPIFlashWidth)
-        dummy_bits:  csr.Field(csr.action.RW, 4)
+        raw_enable:   csr.Field(csr.action.RW, 1)
+        width:        csr.Field(csr.action.RW, QSPIFlashWidth)
+        dummy_bytes:  csr.Field(csr.action.RW, 2)
 
     class RawControl(csr.Register, access="rw"):
         ready: csr.Field(csr.action.R, 1)
@@ -112,6 +112,7 @@ class WishboneQSPIFlashController(wiring.Component):
 
 
         o_addr_count = Signal(range(3))
+        o_dummy_count = Signal(range(4))
         o_data_count = Signal(range(wb_data_octets + 1))
         i_data_count = Signal(range(wb_data_octets + 1))
 
@@ -120,12 +121,34 @@ class WishboneQSPIFlashController(wiring.Component):
         raw_tx_data = Signal(8)
         raw_rx_data = Signal(8)
 
+        o_command = Signal(QSPIFlashCommand, init=QSPIFlashCommand.Read)
+        o_mode = Signal(QSPIMode, init=QSPIMode.PutX1)
+        i_mode = Signal(QSPIMode, init=QSPIMode.GetX1)
+
+        with m.Switch(self._config.f.width.data):
+            with m.Case(QSPIFlashWidth.X1):
+                m.d.comb += o_command.eq(QSPIFlashCommand.Read)
+                m.d.comb += o_mode.eq(QSPIMode.PutX1)
+                m.d.comb += i_mode.eq(QSPIMode.GetX1)
+            with m.Case(QSPIFlashWidth.X1Fast):
+                m.d.comb += o_command.eq(QSPIFlashCommand.FastRead)
+                m.d.comb += o_mode.eq(QSPIMode.PutX1)
+                m.d.comb += i_mode.eq(QSPIMode.GetX1)
+            with m.Case(QSPIFlashWidth.X2):
+                m.d.comb += o_command.eq(QSPIFlashCommand.FastReadDualInOut)
+                m.d.comb += o_mode.eq(QSPIMode.PutX2)
+                m.d.comb += i_mode.eq(QSPIMode.GetX2)
+            with m.Case(QSPIFlashWidth.X4):
+                m.d.comb += o_command.eq(QSPIFlashCommand.FastReadQuadInOut)
+                m.d.comb += o_mode.eq(QSPIMode.PutX4)
+                m.d.comb += i_mode.eq(QSPIMode.GetX4)
+
         with m.FSM() as fsm:
             # WB Memory-mapped mode
             with m.State("Wait"):
                 m.d.comb += self.spi_bus.o_octets.p.chip.eq(1)
                 m.d.comb += self.spi_bus.o_octets.p.mode.eq(QSPIMode.PutX1)
-                m.d.comb += self.spi_bus.o_octets.p.data.eq(QSPIFlashCommand.Read)
+                m.d.comb += self.spi_bus.o_octets.p.data.eq(o_command)
                 with m.If(self._config.f.raw_enable.data):
                     m.next = "Raw-Wait"
                 with m.Elif(self.wb_bus.cyc & self.wb_bus.stb & ~self.wb_bus.we):
@@ -136,18 +159,33 @@ class WishboneQSPIFlashController(wiring.Component):
 
             with m.State("SPI-Address"):
                 m.d.comb += self.spi_bus.o_octets.p.chip.eq(1)
-                m.d.comb += self.spi_bus.o_octets.p.mode.eq(QSPIMode.PutX1)
+                m.d.comb += self.spi_bus.o_octets.p.mode.eq(o_mode)
                 m.d.comb += self.spi_bus.o_octets.p.data.eq(flash_addr.word_select(o_addr_count, 8))
                 m.d.comb += self.spi_bus.o_octets.valid.eq(1)
                 with m.If(self.spi_bus.o_octets.ready):
                     with m.If(o_addr_count != 0):
                         m.d.sync += o_addr_count.eq(o_addr_count - 1)
+                    with m.Elif(self._config.f.dummy_bytes.data != 0):
+                        m.d.sync += o_dummy_count.eq(self._config.f.dummy_bytes.data - 1)
+                        m.next = "SPI-Dummy-Bytes"
                     with m.Else():
                         m.next = "SPI-Data-Read"
 
+            with m.State("SPI-Dummy-Bytes"):
+                m.d.comb += self.spi_bus.o_octets.p.chip.eq(1)
+                m.d.comb += self.spi_bus.o_octets.p.mode.eq(o_mode)
+                m.d.comb += self.spi_bus.o_octets.p.data.eq(0xFF)
+                m.d.comb += self.spi_bus.o_octets.valid.eq(1)
+                with m.If(self.spi_bus.o_octets.ready):
+                    with m.If(o_dummy_count != 0):
+                        m.d.sync += o_dummy_count.eq(o_dummy_count - 1)
+                    with m.Else():
+                        m.next = "SPI-Data-Read"
+
+
             with m.State("SPI-Data-Read"):
                 m.d.comb += self.spi_bus.o_octets.p.chip.eq(1)
-                m.d.comb += self.spi_bus.o_octets.p.mode.eq(QSPIMode.GetX1)
+                m.d.comb += self.spi_bus.o_octets.p.mode.eq(i_mode)
                 with m.If(o_data_count != wb_data_octets):
                     m.d.comb += self.spi_bus.o_octets.valid.eq(1)
                     with m.If(self.spi_bus.o_octets.ready):

--- a/riscv-demo/riscv_demo/ips/qspi/qspi_flash.py
+++ b/riscv-demo/riscv_demo/ips/qspi/qspi_flash.py
@@ -1,9 +1,9 @@
 from amaranth import *
 from amaranth.lib import enum, data, wiring, stream
-from amaranth.lib.wiring import In, Out
+from amaranth.lib.wiring import In, Out, connect, flipped
 from amaranth.utils import exact_log2
 
-from amaranth_soc import wishbone
+from amaranth_soc import wishbone, csr
 from amaranth_soc.memory import MemoryMap
 
 from ..ports import PortGroup
@@ -11,7 +11,6 @@ from .glasgow_qspi import QSPIMode, QSPIController
 
 
 __all__ = ["WishboneQSPIFlashController"]
-
 
 class QSPIFlashCommand(enum.Enum, shape=8):
     Read                = 0x03
@@ -21,10 +20,58 @@ class QSPIFlashCommand(enum.Enum, shape=8):
     FastReadDualInOut   = 0xBB
     FastReadQuadInOut   = 0xEB
 
+class QSPIFlashWidth(enum.Enum, shape=2):
+    X1                = 0x00
+    X1Fast            = 0x01
+    X2                = 0x02
+    X4                = 0x03
+
+class _RawTxDataField(csr.FieldAction):
+    """A field that is read/write and exposes a strobe"""
+    def __init__(self, shape, *, init=0):
+        super().__init__(shape, access="rw", members=(
+            ("data", Out(shape)),
+            ("w_stb", Out(1)),
+        ))
+        self._storage = Signal(shape, init=init)
+
+    def elaborate(self, platform):
+        m = Module()
+
+        with m.If(self.port.w_stb):
+            m.d.sync += self._storage.eq(self.port.w_data)
+
+        m.d.comb += [
+            self.port.r_data.eq(self._storage),
+            self.data.eq(self._storage),
+        ]
+
+        # delayed by one cycle to match storage
+        m.d.sync += self.w_stb.eq(self.port.w_stb)
+
+        return m
 
 class WishboneQSPIFlashController(wiring.Component):
+
+    class Config(csr.Register, access="rw"):
+        raw_enable:  csr.Field(csr.action.RW, 1)
+        width:       csr.Field(csr.action.RW, QSPIFlashWidth)
+        dummy_bits:  csr.Field(csr.action.RW, 4)
+
+    class RawControl(csr.Register, access="rw"):
+        ready: csr.Field(csr.action.R, 1)
+        deselect: csr.Field(csr.action.W, 1)
+
+    class RawTxData(csr.Register, access="rw"):
+        data: csr.Field(_RawTxDataField, 8)
+
+    class RawRxData(csr.Register, access="rw"):
+        data: csr.Field(csr.action.R, 8)
+
+
     def __init__(self, *, addr_width, data_width):
         super().__init__({
+            "csr_bus": In(csr.Signature(addr_width=4, data_width=8)),
             "wb_bus": In(wishbone.Signature(addr_width=addr_width, data_width=data_width, granularity=8)),
             "spi_bus": Out(wiring.Signature({
                 "o_octets": Out(stream.Signature(data.StructLayout({
@@ -43,10 +90,26 @@ class WishboneQSPIFlashController(wiring.Component):
                                            data_width=8)
         self.wb_bus.memory_map.add_resource(self, name="data", size=0x400000) # FIXME
 
+        regs = csr.Builder(addr_width=4, data_width=8)
+
+        self._config      = regs.add("Config",     self.Config(),     offset=0x000)
+        self._raw_control = regs.add("RawControl", self.RawControl(), offset=0x004)
+        self._raw_tx_data = regs.add("RawTxData",  self.RawTxData(),  offset=0x008)
+        self._raw_rx_data = regs.add("RawRxData",  self.RawRxData(),  offset=0x00c)
+
+        self._csr_bridge = csr.Bridge(regs.as_memory_map())
+        self.csr_bus.memory_map = self._csr_bridge.bus.memory_map
+
+
     def elaborate(self, platform):
         m = Module()
 
+        m.submodules.csr_bridge = self._csr_bridge
+
+        connect(m, flipped(self.csr_bus), self._csr_bridge.bus)
+
         wb_data_octets = self.wb_bus.data_width // 8
+
 
         o_addr_count = Signal(range(3))
         o_data_count = Signal(range(wb_data_octets + 1))
@@ -54,12 +117,18 @@ class WishboneQSPIFlashController(wiring.Component):
 
         flash_addr = self.wb_bus.adr << exact_log2(wb_data_octets)
 
-        with m.FSM():
+        raw_tx_data = Signal(8)
+        raw_rx_data = Signal(8)
+
+        with m.FSM() as fsm:
+            # WB Memory-mapped mode
             with m.State("Wait"):
                 m.d.comb += self.spi_bus.o_octets.p.chip.eq(1)
                 m.d.comb += self.spi_bus.o_octets.p.mode.eq(QSPIMode.PutX1)
                 m.d.comb += self.spi_bus.o_octets.p.data.eq(QSPIFlashCommand.Read)
-                with m.If(self.wb_bus.cyc & self.wb_bus.stb & ~self.wb_bus.we):
+                with m.If(self._config.f.raw_enable.data):
+                    m.next = "Raw-Wait"
+                with m.Elif(self.wb_bus.cyc & self.wb_bus.stb & ~self.wb_bus.we):
                     m.d.comb += self.spi_bus.o_octets.valid.eq(1)
                     with m.If(self.spi_bus.o_octets.ready):
                         m.d.sync += o_addr_count.eq(2)
@@ -103,4 +172,39 @@ class WishboneQSPIFlashController(wiring.Component):
                 with m.If(self.spi_bus.o_octets.ready):
                     m.next = "Wait"
 
+            # Raw IO mode
+            with m.State("Raw-Wait"):
+                with m.If(~self._config.f.raw_enable.data):
+                    # Back to Wishbone mode, but make sure to deselect chip first
+                    m.next = "SPI-Deselect"
+                with m.Elif(self._raw_control.f.deselect.w_stb & self._raw_control.f.deselect.w_data):
+                    m.next = "Raw-Deselect"
+                with m.Elif(self._raw_tx_data.f.data.w_stb):
+                    m.d.sync += raw_tx_data.eq(self._raw_tx_data.f.data.data)
+                    m.next = "Raw-Data-Write"
+
+            with m.State("Raw-Data-Write"):
+                m.d.comb += self.spi_bus.o_octets.p.chip.eq(1)
+                m.d.comb += self.spi_bus.o_octets.p.mode.eq(QSPIMode.Swap)
+                m.d.comb += self.spi_bus.o_octets.p.data.eq(raw_tx_data)
+                m.d.comb += self.spi_bus.o_octets.valid.eq(1)
+                with m.If(self.spi_bus.o_octets.ready):
+                    m.next = "Raw-Data-Read"
+
+            with m.State("Raw-Data-Read"):
+                m.d.comb += self.spi_bus.i_octets.ready.eq(1)
+                with m.If(self.spi_bus.i_octets.valid):
+                    m.d.sync += raw_rx_data.eq(self.spi_bus.i_octets.p.data)
+                    m.next = "Raw-Wait"
+
+            with m.State("Raw-Deselect"):
+                m.d.sync += self.wb_bus.ack.eq(0)
+                m.d.comb += self.spi_bus.o_octets.p.chip.eq(0)
+                m.d.comb += self.spi_bus.o_octets.p.mode.eq(QSPIMode.Dummy)
+                m.d.comb += self.spi_bus.o_octets.valid.eq(1)
+                with m.If(self.spi_bus.o_octets.ready):
+                    m.next = "Raw-Wait"
+
+            m.d.comb += self._raw_rx_data.f.data.r_data.eq(raw_rx_data)
+            m.d.comb += self._raw_control.f.ready.r_data.eq(fsm.ongoing("Raw-Wait"))
         return m

--- a/riscv-demo/riscv_demo/soc.py
+++ b/riscv-demo/riscv_demo/soc.py
@@ -60,6 +60,7 @@ class DemoSoC(wiring.Component):
         m.submodules.qspi = qspi
         m.submodules.spiflash = spiflash
 
+        csr_decoder.add(spiflash.csr_bus, name="spiflash", addr=self.csr_spiflash_base - self.csr_base)
         wb_decoder.add(spiflash.wb_bus, name="spiflash", addr=self.mem_spiflash_base)
 
         connect(m, spiflash.spi_bus, qspi)

--- a/riscv-demo/riscv_demo/test_sw/.gitignore
+++ b/riscv-demo/riscv_demo/test_sw/.gitignore
@@ -1,0 +1,4 @@
+*.d
+*.elf
+*.dasm
+*bin

--- a/riscv-demo/riscv_demo/test_sw/Makefile
+++ b/riscv-demo/riscv_demo/test_sw/Makefile
@@ -1,0 +1,7 @@
+all: test.bin
+
+test.elf: sections.lds start.s flashio.s main.c
+	riscv64-unknown-elf-gcc -g -march=rv32i -mabi=ilp32 -Wl,--build-id=none,-Bstatic,-T,sections.lds,--strip-debug -static -ffreestanding -nostdlib -o test.elf start.s flashio.s main.c
+
+test.bin: test.elf
+	riscv64-unknown-elf-objcopy -O binary test.elf test.bin

--- a/riscv-demo/riscv_demo/test_sw/flashio.s
+++ b/riscv-demo/riscv_demo/test_sw/flashio.s
@@ -1,0 +1,57 @@
+.global flashio_worker_begin
+.global flashio_worker_end
+
+.balign 4
+
+flashio_worker_begin:
+# a0 ... data pointer
+# a1 ... data length
+# a2 ... optional WREN cmd (0 = disable)
+
+mv t3, ra
+
+# address of SPI ctrl reg
+li   t0, 0xb0000000
+# enter bypass mode
+lbu   t1, 0(t0) 
+ori   t1, t1, 0x1
+sb    t1, 0(t0)
+call flashio_wait_bypass_ready
+
+beqz a2, flashio_xfer
+
+sb a2, 8(t0) # send wren
+call flashio_wait_bypass_ready
+li t1, 2 # deselect
+sb t1, 4(t0)
+call flashio_wait_bypass_ready
+
+flashio_xfer:
+beqz a1, flashio_done
+lbu t1, 0(a0)
+sb t1, 8(t0) # tx data
+call flashio_wait_bypass_ready
+lbu t1, 12(t0) # rx data
+sb t1, 0(a0)
+addi a0, a0, 1
+addi a1, a1, -1
+j flashio_xfer
+
+flashio_done:
+# exit bypass mode
+lbu   t1, 0(t0) 
+andi   t1, t1, 0xFE
+sb    t1, 0(t0)
+
+fence.i
+mv ra, t3
+ret
+
+flashio_wait_bypass_ready:
+lbu   t1, 4(t0)
+andi t1, t1, 0x1
+beqz t1, flashio_wait_bypass_ready
+ret
+
+.balign 4
+flashio_worker_end:

--- a/riscv-demo/riscv_demo/test_sw/main.c
+++ b/riscv-demo/riscv_demo/test_sw/main.c
@@ -1,0 +1,120 @@
+#include <stdint.h>
+
+struct uart_chipflow_regs {
+    uint32_t config;
+    uint32_t phy_config;
+    uint32_t status;
+    uint32_t data;
+};
+
+
+struct uart_chipflow_regs *const UART_RX = (struct uart_chipflow_regs*)(0xb2000000);
+struct uart_chipflow_regs *const UART_TX = (struct uart_chipflow_regs*)(0xb2000200);
+
+static const uint32_t divisor  = (48000000 / 115200 - 1);
+
+static void uart_init() {
+    UART_RX->config = 0;
+    UART_TX->config = 0;
+    UART_RX->phy_config = divisor & 0x00FFFFFF;
+    UART_TX->phy_config = divisor & 0x00FFFFFF;
+    UART_RX->config = 1;
+    UART_TX->config = 1;
+};
+
+static void putc(char c) {
+    if (c == '\n')
+        putc('\r');
+    while (!(UART_TX->status & 0x1));
+        ;
+    UART_TX->data = (uint32_t)c;
+}
+
+static void puts(const char *s) {
+    while (*s != 0)
+        putc(*s++);
+}
+
+
+static void puthex(uint32_t x) {
+    for (int i = 7; i >= 0; i--) {
+        uint8_t nib = (x >> (4 * i)) & 0xF;
+        if (nib <= 9)
+            putc('0' + nib);
+        else
+            putc('A' + (nib - 10));
+    }
+}
+
+extern uint32_t flashio_worker_begin;
+extern uint32_t flashio_worker_end;
+
+struct qspi_flash_regs {
+    uint32_t config;
+    uint32_t raw_control;
+    uint32_t raw_tx_data;
+    uint32_t raw_rx_data;
+};
+
+struct qspi_flash_regs *const QSPI_FLASH = (struct qspi_flash_regs*)(0xb0000000);
+
+void flashio(uint8_t *data, int len, uint8_t wrencmd)
+{
+    volatile uint32_t func[&flashio_worker_end - &flashio_worker_begin];
+
+    // Can't execute off flash while talking to it, so copy IO code to SRAM
+    uint32_t *src_ptr = &flashio_worker_begin;
+    volatile uint32_t *dst_ptr = func;
+
+    while (src_ptr != &flashio_worker_end)
+        *(dst_ptr++) = *(src_ptr++);
+
+    __asm__ volatile ("fence.i" : : : "memory");
+
+    ((void(*)(uint8_t*, uint32_t, uint32_t))func)(data, len, wrencmd);
+}
+
+void read_flash_id()
+{
+    uint8_t buffer[5] = { 0x9F, /* zeros */ };
+    flashio(buffer, 5, 0);
+
+    uint32_t id = 0;
+    for (int i = 1; i <= 4; i++) {
+        id = id << 8U;
+        id |= buffer[i];
+    }
+    puts("Flash ID: ");
+    puthex(id);
+    puts("\n");
+}
+
+void set_flash_qspi_flag()
+{
+    uint8_t buffer[8];
+
+    // Read Configuration Registers (RDCR1 35h)
+    buffer[0] = 0x35;
+    buffer[1] = 0x00; // rdata
+    flashio(buffer, 2, 0);
+    uint8_t sr2 = buffer[1];
+
+    // Write Enable Volatile (50h) + Write Status Register 2 (31h)
+    buffer[0] = 0x31;
+    buffer[1] = sr2 | 2; // Enable QSPI
+    flashio(buffer, 2, 0x50);
+}
+
+void enter_qspi_mode() {
+    QSPI_FLASH->config = (0x1U << 3U) | (0x03U << 1U); // 1 dummy byte, X4 mode
+}
+
+void main() {
+    uart_init();
+    puts("Hello World!\n");
+    read_flash_id();
+    set_flash_qspi_flag();
+    puts("Set QSPI flag\n");
+    enter_qspi_mode();
+    puts("In QSPI mode\n");
+}

--- a/riscv-demo/riscv_demo/test_sw/sections.lds
+++ b/riscv-demo/riscv_demo/test_sw/sections.lds
@@ -1,0 +1,64 @@
+
+MEMORY
+{
+    FLASH (rx)      : ORIGIN = 0x00100000, LENGTH = 0x400000 /* entire flash, 4 MiB */
+    RAM (xrw)       : ORIGIN = 0x10000000, LENGTH = 0x400  /* SRAM, 1 KiB */
+}
+
+SECTIONS {
+    /* The program code and other data goes into FLASH */
+    .text :
+    {
+        . = ALIGN(4);
+        *(.text)           /* .text sections (code) */
+        *(.text*)          /* .text* sections (code) */
+        *(.rodata)         /* .rodata sections (constants, strings, etc.) */
+        *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
+        *(.srodata)        /* .rodata sections (constants, strings, etc.) */
+        *(.srodata*)       /* .rodata* sections (constants, strings, etc.) */
+        . = ALIGN(4);
+        _etext = .;        /* define a global symbol at end of code */
+        _sidata = _etext;  /* This is used by the startup in order to initialize the .data secion */
+    } >FLASH
+
+
+    /* This is the initialized data section
+    The program executes knowing that the data is in the RAM
+    but the loader puts the initial values in the FLASH (inidata).
+    It is one task of the startup to copy the initial values from FLASH to RAM. */
+    .data : AT ( _sidata )
+    {
+        . = ALIGN(4);
+        _sdata = .;        /* create a global symbol at data start; used by startup code in order to initialise the .data section in RAM */
+        _ram_start = .;    /* create a global symbol at ram start for garbage collector */
+        . = ALIGN(4);
+        *(.data)           /* .data sections */
+        *(.data*)          /* .data* sections */
+        *(.sdata)           /* .sdata sections */
+        *(.sdata*)          /* .sdata* sections */
+        . = ALIGN(4);
+        _edata = .;        /* define a global symbol at data end; used by startup code in order to initialise the .data section in RAM */
+    } >RAM
+
+    /* Uninitialized data section */
+    .bss :
+    {
+        . = ALIGN(4);
+        _sbss = .;         /* define a global symbol at bss start; used by startup code */
+        *(.bss)
+        *(.bss*)
+        *(.sbss)
+        *(.sbss*)
+        *(COMMON)
+
+        . = ALIGN(4);
+        _ebss = .;         /* define a global symbol at bss end; used by startup code */
+    } >RAM
+
+    /* this is to define the start of the heap, and make sure we have a minimum size */
+    .heap :
+    {
+        . = ALIGN(4);
+        _heap_start = .;    /* define a global symbol at heap start */
+    } >RAM
+}

--- a/riscv-demo/riscv_demo/test_sw/start.s
+++ b/riscv-demo/riscv_demo/test_sw/start.s
@@ -1,0 +1,63 @@
+.section .text
+
+start:
+
+# zero-initialize register file
+addi x1, zero, 0
+li x2, 0x10000400 # Top of stack
+addi x3, zero, 0
+addi x4, zero, 0
+addi x5, zero, 0
+addi x6, zero, 0
+addi x7, zero, 0
+addi x8, zero, 0
+addi x9, zero, 0
+addi x10, zero, 0
+addi x11, zero, 0
+addi x12, zero, 0
+addi x13, zero, 0
+addi x14, zero, 0
+addi x15, zero, 0
+addi x16, zero, 0
+addi x17, zero, 0
+addi x18, zero, 0
+addi x19, zero, 0
+addi x20, zero, 0
+addi x21, zero, 0
+addi x22, zero, 0
+addi x23, zero, 0
+addi x24, zero, 0
+addi x25, zero, 0
+addi x27, zero, 0
+addi x28, zero, 0
+addi x29, zero, 0
+addi x30, zero, 0
+addi x31, zero, 0
+
+# copy data section
+la a0, _sidata
+la a1, _sdata
+la a2, _edata
+bge a1, a2, end_init_data
+loop_init_data:
+lw a3, 0(a0)
+sw a3, 0(a1)
+addi a0, a0, 4
+addi a1, a1, 4
+blt a1, a2, loop_init_data
+end_init_data:
+
+# zero-init bss section
+la a0, _sbss
+la a1, _ebss
+bge a0, a1, end_init_bss
+loop_init_bss:
+sw zero, 0(a0)
+addi a0, a0, 4
+blt a0, a1, loop_init_bss
+end_init_bss:
+
+# call main
+call main
+loop:
+j loop

--- a/riscv-demo/tests/test_qspi.py
+++ b/riscv-demo/tests/test_qspi.py
@@ -15,6 +15,7 @@ class _QSPIFlashCommand(enum.Enum, shape=8):
     FastReadQuadOut     = 0x6B
     FastReadDualInOut   = 0xBB
     FastReadQuadInOut   = 0xEB
+    ReadID              = 0x9F
 
 
 class _MockFlash(wiring.Component):
@@ -40,16 +41,26 @@ class _MockFlash(wiring.Component):
         m.d.sync += self.i_octets.valid.eq(0) # default
 
         with m.FSM():
-            with m.State("IDLE"):
+            with m.State("Idle"):
                 with m.If(self.o_octets.valid):
-                    m.d.sync += [
-                        Assert(self.o_octets.p.chip == 1),
-                        Assert(self.o_octets.p.mode == QSPIMode.PutX1),
-                        command.eq(self.o_octets.p.data),
-                        address_count.eq(2)
-                    ]
-                    m.next = "ADDRESS"
-            with m.State("ADDRESS"):
+                    with m.If(self.o_octets.p.mode == QSPIMode.Dummy):
+                        m.next = "Idle"
+                    with m.Else():
+                        m.d.sync += [
+                            Assert(self.o_octets.p.chip == 1),
+                            Assert((self.o_octets.p.mode == QSPIMode.PutX1) | (self.o_octets.p.mode == QSPIMode.Swap)),
+                            command.eq(self.o_octets.p.data),
+                            address_count.eq(2)
+                        ]
+                        with m.If(self.o_octets.p.mode == QSPIMode.Swap):
+                            # send a dummy response to the swap
+                            m.d.sync += self.i_octets.valid.eq(1)
+                            m.d.sync += self.i_octets.p.data.eq(0xFF)
+                        with m.If(self.o_octets.p.data == _QSPIFlashCommand.ReadID):
+                            m.next = "Send-ID"
+                        with m.Else():
+                            m.next = "Get-Address"
+            with m.State("Get-Address"):
                 with m.If(self.o_octets.valid):
                     m.d.sync += [
                         Assert(self.o_octets.p.chip == 1),
@@ -58,11 +69,11 @@ class _MockFlash(wiring.Component):
                         address_count.eq(address_count - 1)
                     ]
                     with m.If(address_count == 0):
-                        m.next = "DATA"
-            with m.State("DATA"):
+                        m.next = "Send-Data"
+            with m.State("Send-Data"):
                 with m.If(self.o_octets.valid):
                     with m.If(self.o_octets.p.mode == QSPIMode.Dummy):
-                        m.next = "IDLE"
+                        m.next = "Idle"
                     with m.Else():
                         m.d.sync += [
                             Assert(self.o_octets.p.chip == 1),
@@ -72,7 +83,18 @@ class _MockFlash(wiring.Component):
                             self.i_octets.valid.eq(1),
                             address.eq(address + 1)
                         ]
-
+            with m.State("Send-ID"):
+                with m.If(self.o_octets.valid):
+                    with m.If(self.o_octets.p.mode == QSPIMode.Dummy):
+                        m.next = "Idle"
+                    with m.Else():
+                        m.d.sync += [
+                            Assert(self.o_octets.p.chip == 1),
+                            Assert(self.o_octets.p.mode == QSPIMode.Swap),
+                            self.i_octets.p.data.eq(C(0xEF4018, 24).word_select(address_count, 8)),
+                            self.i_octets.valid.eq(1),
+                            address_count.eq(address_count - 1)
+                        ]
         return m
 
 async def _wb_read(self, ctx, dut, addr, r_data):
@@ -87,6 +109,24 @@ async def _wb_read(self, ctx, dut, addr, r_data):
     ctx.set(dut.wb_bus.stb, 0)
     self.assertEqual(ctx.get(dut.wb_bus.dat_r), r_data)
 
+async def _csr_access(self, ctx, dut, addr, r_stb=0, r_data=0, w_stb=0, w_data=0):
+
+    ctx.set(dut.csr_bus.addr, addr)
+    ctx.set(dut.csr_bus.r_stb, r_stb)
+    ctx.set(dut.csr_bus.w_stb, w_stb)
+    ctx.set(dut.csr_bus.w_data, w_data)
+
+    await ctx.tick()
+
+    if r_stb:
+        self.assertEqual(ctx.get(dut.csr_bus.r_data), r_data)
+
+    ctx.set(dut.csr_bus.r_stb, 0)
+    ctx.set(dut.csr_bus.w_stb, 0)
+
+
+
+
 class QSPITestCase(unittest.TestCase):
     def test_sim(self):
         dut = WishboneQSPIFlashController(addr_width=24, data_width=32)
@@ -98,8 +138,37 @@ class QSPITestCase(unittest.TestCase):
 
         connect(m, dut.spi_bus, phy)
 
+        config_addr       = 0x000
+        raw_control_addr  = 0x004
+        raw_tx_data_addr  = 0x008
+        raw_rx_data_addr  = 0x00c
+
         async def testbench(ctx):
             await _wb_read(self, ctx, dut, 0x0, 0xa9a8abaa)
+            await _wb_read(self, ctx, dut, 0x4, 0xadacafae)
+
+            # in WB mode: bypass mode not ready
+            await _csr_access(self, ctx, dut, raw_control_addr, r_stb=1, r_data=0)
+            # enter bypass mode
+            await _csr_access(self, ctx, dut, config_addr, w_stb=1, w_data=1)
+            for _ in range(10): await ctx.tick()
+            # in bypass mode: bypass ready
+            await _csr_access(self, ctx, dut, raw_control_addr, r_stb=1, r_data=1)
+            # read ID command
+            await _csr_access(self, ctx, dut, raw_tx_data_addr, w_stb=1, w_data=_QSPIFlashCommand.ReadID)
+            for _ in range(4): await ctx.tick()
+            for byte in reversed(range(3)):
+                await _csr_access(self, ctx, dut, raw_tx_data_addr, w_stb=1, w_data=0xFF)
+                for _ in range(4): await ctx.tick()
+                await _csr_access(self, ctx, dut, raw_rx_data_addr, r_stb=1, r_data=((0xEF4018 >> (8 * byte)) & 0xFF))
+
+            # exit bypass mode
+            await _csr_access(self, ctx, dut, config_addr, w_stb=1, w_data=0)
+            for _ in range(10): await ctx.tick()
+            # in WB mode: bypass mode not ready
+            await _csr_access(self, ctx, dut, raw_control_addr, r_stb=1, r_data=0)
+
+            # check that WB functions again
             await _wb_read(self, ctx, dut, 0x4, 0xadacafae)
 
         sim = Simulator(m)
@@ -107,4 +176,3 @@ class QSPITestCase(unittest.TestCase):
         sim.add_testbench(testbench)
         with sim.write_vcd(vcd_file="test_qspi.vcd"):
             sim.run()
-

--- a/riscv-demo/tests/test_qspi.py
+++ b/riscv-demo/tests/test_qspi.py
@@ -31,14 +31,37 @@ class _MockFlash(wiring.Component):
             "divisor": In(16),
         })
 
+        # exposed for testbench
+        self.last_command = Signal(_QSPIFlashCommand, init=_QSPIFlashCommand.Read)
+
     def elaborate(self, platform):
         m = Module()
         command = Signal(_QSPIFlashCommand, init=_QSPIFlashCommand.Read)
         address_count = Signal(2)
+        dummy_count = Signal(2)
         address = Signal(24)
 
         m.d.comb += self.o_octets.ready.eq(1)
         m.d.sync += self.i_octets.valid.eq(0) # default
+
+        dummy_bytes = Signal(2)
+        expected_addr_mode = Signal(QSPIMode, init=QSPIMode.Dummy)
+        expected_data_mode = Signal(QSPIMode, init=QSPIMode.Dummy)
+
+        with m.Switch(command):
+            with m.Case(_QSPIFlashCommand.Read):
+                m.d.comb += [
+                    dummy_bytes.eq(0),
+                    expected_addr_mode.eq(QSPIMode.PutX1),
+                    expected_data_mode.eq(QSPIMode.GetX1),
+                ]
+            with m.Case(_QSPIFlashCommand.FastRead):
+                m.d.comb += [
+                    dummy_bytes.eq(1),
+                    expected_addr_mode.eq(QSPIMode.PutX1),
+                    expected_data_mode.eq(QSPIMode.GetX1),
+                ]
+
 
         with m.FSM():
             with m.State("Idle"):
@@ -64,11 +87,24 @@ class _MockFlash(wiring.Component):
                 with m.If(self.o_octets.valid):
                     m.d.sync += [
                         Assert(self.o_octets.p.chip == 1),
-                        Assert(self.o_octets.p.mode == QSPIMode.PutX1),
+                        Assert(self.o_octets.p.mode == expected_addr_mode),
                         address.word_select(address_count, 8).eq(self.o_octets.p.data),
                         address_count.eq(address_count - 1)
                     ]
                     with m.If(address_count == 0):
+                        with m.If(dummy_bytes == 0):
+                            m.next = "Send-Data"
+                        with m.Else():
+                            m.d.sync += dummy_count.eq(dummy_bytes - 1)
+                            m.next = "Get-Dummy"
+            with m.State("Get-Dummy"):
+                with m.If(self.o_octets.valid):
+                    m.d.sync += [
+                        Assert(self.o_octets.p.chip == 1),
+                        Assert(self.o_octets.p.mode == expected_addr_mode),
+                        dummy_count.eq(dummy_count - 1)
+                    ]
+                    with m.If(dummy_count == 0):
                         m.next = "Send-Data"
             with m.State("Send-Data"):
                 with m.If(self.o_octets.valid):
@@ -77,7 +113,7 @@ class _MockFlash(wiring.Component):
                     with m.Else():
                         m.d.sync += [
                             Assert(self.o_octets.p.chip == 1),
-                            Assert(self.o_octets.p.mode == QSPIMode.GetX1),
+                            Assert(self.o_octets.p.mode == expected_data_mode),
                             Assert(self.i_octets.ready == 1), # TODO: allowed to be not ready, too
                             self.i_octets.p.data.eq(0xAA ^ address[0:8]), # TODO: something more useful here
                             self.i_octets.valid.eq(1),
@@ -95,6 +131,7 @@ class _MockFlash(wiring.Component):
                             self.i_octets.valid.eq(1),
                             address_count.eq(address_count - 1)
                         ]
+        m.d.comb += self.last_command.eq(command)
         return m
 
 async def _wb_read(self, ctx, dut, addr, r_data):
@@ -147,6 +184,9 @@ class QSPITestCase(unittest.TestCase):
             await _wb_read(self, ctx, dut, 0x0, 0xa9a8abaa)
             await _wb_read(self, ctx, dut, 0x4, 0xadacafae)
 
+            # check default mode is regular read
+            self.assertEqual(ctx.get(phy.last_command), _QSPIFlashCommand.Read)
+
             # in WB mode: bypass mode not ready
             await _csr_access(self, ctx, dut, raw_control_addr, r_stb=1, r_data=0)
             # enter bypass mode
@@ -170,6 +210,13 @@ class QSPITestCase(unittest.TestCase):
 
             # check that WB functions again
             await _wb_read(self, ctx, dut, 0x4, 0xadacafae)
+
+            # switch to fast read mode
+            await _csr_access(self, ctx, dut, config_addr, w_stb=1, w_data=(0x01 << 1) | (0x01 << 3)) # X1Fast, 1 dummy byte
+            for _ in range(1): await ctx.tick()
+            # check fast read mode
+            await _wb_read(self, ctx, dut, 0x4, 0xadacafae)
+            self.assertEqual(ctx.get(phy.last_command), _QSPIFlashCommand.FastRead)
 
         sim = Simulator(m)
         sim.add_clock(period=1 / 48e6)


### PR DESCRIPTION
This adds a CSR interface to allow direct SPI transfers away from the Wishbone memory-mapped interface, allowing things like reading flash ID or enabling QSPI modes.

